### PR TITLE
Add canonical rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,17 +1,17 @@
 AllCops:
   TargetRubyVersion: 2.3
   Exclude:
+    - '**/*_pb.rb'
     - 'app/controllers/devise_custom/**/*'
+    - 'app/reports/*'
     - 'bin/*'
     - 'config/**/*'
-    - 'app/reports/*'
     - 'Gemfile'
     - 'Guardfile'
     - 'Rakefile'
-    - 'tmp/**/*'
     - 'spec/dummy/**/*'
+    - 'tmp/**/*'
     - 'vendor/bundle/**/*'
-    - '**/*_pb.rb'
 Metrics/AbcSize:
   Enabled: true
   Max: 16


### PR DESCRIPTION
Copied this from our repos and merged together. Sorted cops alphabetically and added namespace.

Questions and issues:
- the exclusion list might be project specific (e.g. the `app/reports/*`)
- removed `db/` and `scripts/` from exclusion list since these folders typically contain files with no specs so i think consistent styling is even more important for these

[#135012837]