### PR TITLE
disable empty method style cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,7 +44,7 @@ Style/Documentation:
 Style/PredicateName:
   Enabled: false
 Style/EmptyMethod:
-  Enabled: false
+  EnforcedStyle: expanded
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%i': ()

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,8 @@ Style/Documentation:
   Enabled: false
 Style/PredicateName:
   Enabled: false
+Style/EmptyMethod:
+  Enabled: false
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%i': ()


### PR DESCRIPTION
The default behaviour of rubocop enforces compact empty method style - on a single line. It looks pretty nasty though (`def index; end`).
In admin, internally, we agreed to the expanded version a while ago. In some other projects I’ve seen the compact version as well so the best would be to disable the setting.