### PR TITLE
Prefer to use receive over have_received to create stubs.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,7 +39,7 @@ RSpec/MultipleExpectations:
 RSpec/NestedGroups:
   Enabled: false
 RSpec/MessageSpies:
-  EnforcedStyle: receive
+  Enabled: false
 Style/SignalException:
   Enabled: false
 Style/Documentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,8 @@ RSpec/MultipleExpectations:
   Enabled: false
 RSpec/NestedGroups:
   Enabled: false
+RSpec/MessageSpies:
+  EnforcedStyle: receive
 Style/SignalException:
   Enabled: false
 Style/Documentation:


### PR DESCRIPTION
From some time rubocop is yielding such errors:

> Prefer have_received for setting message expectations. Setup form as a spy using allow or instance_spy.

So far, we have mostly used `receive` in our projects, 625 occurrences, while  `have_received` there are 41 (many is quite recent).

From what I spoke to the local team, we still do prefer `receive`. Both are supported by rubocop but `have_received` is preferred by default.