### PR TITLE
Increasing the max rspec examples length

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,8 @@ Rails/ActionFilter:
   Enabled: false
 Rails/HttpPositionalArguments:
   Enabled: false
+RSpec/ExampleLength:
+  Max: 10
 RSpec/MultipleExpectations:
   Enabled: false
 RSpec/NestedGroups:


### PR DESCRIPTION
Even though I try to have just one test for an example, sometimes it's difficult to express all expectations in 5 lines without loosing readability.