### PR TITLE
Move PredicateName to correct namespace

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,8 @@ Metrics/LineLength:
   Max: 120
 Metrics/MethodLength:
   Enabled: true
+Naming/PredicateName:
+  Enabled: false
 Rails/ActionFilter:
   Enabled: false
 Rails/HttpPositionalArguments:
@@ -43,8 +45,6 @@ RSpec/MessageSpies:
 Style/SignalException:
   Enabled: false
 Style/Documentation:
-  Enabled: false
-Style/PredicateName:
   Enabled: false
 Style/EmptyMethod:
   EnforcedStyle: expanded


### PR DESCRIPTION
Not sure why this has changed, but I'm getting this error locally:
```
Style/PredicateName has the wrong namespace - should be Naming
```