### PR TITLE
enabling rails cops since codeclimate does not run rubocop with -R

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,9 @@ Rails/ActionFilter:
   Enabled: false
 Rails/HttpPositionalArguments:
   Enabled: false
+Rails/SkipsModelValidations:
+  Exclude:
+    - 'db/migrate/**/*.rb'
 RSpec/ExampleLength:
   Max: 10
 RSpec/MultipleExpectations:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,8 @@ Metrics/MethodLength:
   Enabled: true
 Naming/PredicateName:
   Enabled: false
+Rails:
+  Enabled: true
 Rails/ActionFilter:
   Enabled: false
 Rails/HttpPositionalArguments:


### PR DESCRIPTION
while codereviewing it was proposed that we check for `validates_attribute_of` usage and prevent it
upon looking at our configuration it turned out that we are not using rails cops – they can be enabled either by:
* running rubocop with -R flag
* adding Rails: Enable: true to the .rubocop.yml

otherwise, they are [disabled by default](https://github.com/bbatsov/rubocop/blob/master/config/disabled.yml#L32)

A discussion should be held as to which of the rails cops we would like to have enabled.
[This](https://gist.github.com/dominika/2c428598331ff7dcb1e22e7a3a3a5f60/revisions) is the list of cops that would be turned on while enabling Rails cops. For the ones we do not want, we should disable them in the .rubocop.yml

(It should be noted that the severity of the cops mentioned is not error)